### PR TITLE
Added support to group notifications to exclude a user.

### DIFF
--- a/webpush/__init__.py
+++ b/webpush/__init__.py
@@ -2,11 +2,9 @@ import json
 
 from .utils import send_notification_to_group, send_notification_to_user
 
-
-def send_group_notification(group_name, payload, ttl=0):
+def send_group_notification(group_name, payload, ttl=0, exclude_user_id=None):
     payload = json.dumps(payload)
-    send_notification_to_group(group_name, payload, ttl)
-
+    send_notification_to_group(group_name, payload, ttl, exclude_user_id)
 
 def send_user_notification(user, payload, ttl=0):
     payload = json.dumps(payload)


### PR DESCRIPTION
Added support to group notifications to exclude a user. This allows for more granular control when sending group notifications, enabling the exclusion of a specific user from the recipient list. For example, when a user sends a notification to a group he belongs to, he can now be excluded from recieving the notification him/herself

This modification is backward-compatible and aligns with the recent changes made to `send_notification_to_group`.